### PR TITLE
Pass prk len to mitosis_cmac_init

### DIFF
--- a/mitosis-crypto/mitosis-keys.c
+++ b/mitosis-crypto/mitosis-keys.c
@@ -51,7 +51,7 @@ bool mitosis_crypto_init(mitosis_crypto_context_t* context, bool left) {
         return result;
     }
 
-    result = mitosis_cmac_init(&(context->cmac), prk);
+    result = mitosis_cmac_init(&(context->cmac), prk, sizeof(prk));
     if(!result) {
         return result;
     }


### PR DESCRIPTION
The current code won't build as `mitosis_cmac_init` is missing `prk_len`.